### PR TITLE
Feature/2 Add command override, click actions, and jump-back binding

### DIFF
--- a/marmonitor.tmux
+++ b/marmonitor.tmux
@@ -89,6 +89,10 @@ fi
 # Set refresh interval
 tmux set -g status-interval "$status_interval"
 
+# Click attention pills / jump-back in statusline
+tmux unbind-key -n MouseDown1Status 2>/dev/null || true
+tmux bind-key -n MouseDown1Status run-shell -b "sh -lc '$MARMONITOR_CMD status-click \"#{mouse_status_range}\" --client-tty \"#{client_tty}\" >/dev/null 2>&1'"
+
 # ─── Key bindings ─────────────────────────────────────────────────────
 
 # Conflict check helper: warn if key is already bound (but still bind)
@@ -108,11 +112,11 @@ check_key_conflict() {
 
 # Attention popup (prefix + key)
 check_key_conflict "$attention_key" prefix
-tmux bind-key "$attention_key" display-popup -E -w 120 -h 32 "sh -lc '$MARMONITOR_CMD attention --interactive --limit 12'"
+tmux bind-key "$attention_key" display-popup -E -w 120 -h 42 "sh -lc '$MARMONITOR_CMD attention --interactive --limit 12'"
 
 # Jump popup (prefix + key)
 check_key_conflict "$jump_key" prefix
-tmux bind-key "$jump_key" display-popup -E -w 120 -h 32 "sh -lc '$MARMONITOR_CMD jump --attention'"
+tmux bind-key "$jump_key" display-popup -E -w 120 -h 42 "sh -lc '$MARMONITOR_CMD jump --attention'"
 
 # Dock toggle (prefix + key)
 check_key_conflict "$dock_key" prefix
@@ -124,4 +128,8 @@ if [ "$direct_jump" = "on" ]; then
     check_key_conflict "M-$i" root
     tmux bind-key -n "M-$i" run-shell -b "sh -lc '$MARMONITOR_CMD jump --attention-index $i >/dev/null 2>&1'"
   done
+
+  # Jump-back (Option+6)
+  check_key_conflict "M-6" root
+  tmux bind-key -n "M-6" run-shell -b "sh -lc '$MARMONITOR_CMD jump-back >/dev/null 2>&1'"
 fi

--- a/marmonitor.tmux
+++ b/marmonitor.tmux
@@ -23,11 +23,27 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+command_runs() {
+  sh -lc "$1 --version >/dev/null 2>&1"
+}
+
 # ─── Preflight ────────────────────────────────────────────────────────
 
-if ! command_exists marmonitor; then
-  tmux display-message "marmonitor-tmux: 'marmonitor' not found. Run: npm install -g marmonitor"
-  exit 0
+# Allow custom marmonitor command (e.g. local dev path)
+MARMONITOR_CMD=$(get_opt "@marmonitor-command" "marmonitor")
+
+if ! command_runs "$MARMONITOR_CMD"; then
+  # Try common paths as fallback
+  for candidate in /opt/homebrew/bin/marmonitor /usr/local/bin/marmonitor; do
+    if [ -x "$candidate" ] && sh -lc "$candidate --version >/dev/null 2>&1"; then
+      MARMONITOR_CMD="$candidate"
+      break
+    fi
+  done
+  if ! command_runs "$MARMONITOR_CMD"; then
+    tmux display-message "marmonitor-tmux: 'marmonitor' not found. Run: npm install -g marmonitor"
+    exit 0
+  fi
 fi
 
 # ─── Read user options ────────────────────────────────────────────────
@@ -62,7 +78,7 @@ fi
 
 # ─── Set statusline ──────────────────────────────────────────────────
 
-statusline_cmd="#[bg=#1e1e2e]#[fg=#cdd6f4]#($CURRENT_DIR/scripts/statusline.sh '${format}') "
+statusline_cmd="#[bg=#1e1e2e]#[fg=#cdd6f4]#($CURRENT_DIR/scripts/statusline.sh '${format}' \"${MARMONITOR_CMD}\") "
 
 # Check if this status-format line is already set by us (avoid duplicates on reload)
 current_format=$(tmux show-option -gqv "status-format[${status_line}]" 2>/dev/null)
@@ -92,20 +108,20 @@ check_key_conflict() {
 
 # Attention popup (prefix + key)
 check_key_conflict "$attention_key" prefix
-tmux bind-key "$attention_key" display-popup -E -w 120 -h 32 "marmonitor attention --interactive --limit 12"
+tmux bind-key "$attention_key" display-popup -E -w 120 -h 32 "sh -lc '$MARMONITOR_CMD attention --interactive --limit 12'"
 
 # Jump popup (prefix + key)
 check_key_conflict "$jump_key" prefix
-tmux bind-key "$jump_key" display-popup -E -w 120 -h 32 "marmonitor jump --attention"
+tmux bind-key "$jump_key" display-popup -E -w 120 -h 32 "sh -lc '$MARMONITOR_CMD jump --attention'"
 
 # Dock toggle (prefix + key)
 check_key_conflict "$dock_key" prefix
-tmux bind-key "$dock_key" run-shell "$CURRENT_DIR/scripts/toggle-dock.sh"
+tmux bind-key "$dock_key" run-shell "$CURRENT_DIR/scripts/toggle-dock.sh \"$MARMONITOR_CMD\""
 
 # Direct jump by number (Option+1~5)
 if [ "$direct_jump" = "on" ]; then
   for i in 1 2 3 4 5; do
     check_key_conflict "M-$i" root
-    tmux bind-key -n "M-$i" run-shell -b "marmonitor jump --attention-index $i >/dev/null 2>&1"
+    tmux bind-key -n "M-$i" run-shell -b "sh -lc '$MARMONITOR_CMD jump --attention-index $i >/dev/null 2>&1'"
   done
 fi

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -5,10 +5,25 @@
 #
 
 FORMAT="${1:-tmux-badges}"
+MARMONITOR_CMD="${2:-marmonitor}"
 
-if ! command -v marmonitor >/dev/null 2>&1; then
+command_runs() {
+  sh -lc "$1 --version >/dev/null 2>&1"
+}
+
+# Try configured command, then common paths
+if ! command_runs "$MARMONITOR_CMD"; then
+  for candidate in /opt/homebrew/bin/marmonitor /usr/local/bin/marmonitor; do
+    if [ -x "$candidate" ] && sh -lc "$candidate --version >/dev/null 2>&1"; then
+      MARMONITOR_CMD="$candidate"
+      break
+    fi
+  done
+fi
+
+if ! command_runs "$MARMONITOR_CMD"; then
   echo "#[fg=yellow]marmonitor not found#[default]"
   exit 0
 fi
 
-marmonitor --statusline --statusline-format "$FORMAT" 2>/dev/null || echo ""
+sh -lc "$MARMONITOR_CMD --statusline --statusline-format \"$FORMAT\"" 2>/dev/null || echo ""

--- a/scripts/toggle-dock.sh
+++ b/scripts/toggle-dock.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 DOCK_TITLE="marmonitor-dock"
-DOCK_CMD="marmonitor dock --lines 12"
+MARMONITOR_CMD="${1:-marmonitor}"
+DOCK_CMD="sh -lc '$MARMONITOR_CMD dock --lines 12'"
 
 existing_pane="$(
   tmux list-panes -F '#{pane_id} #{pane_title}' 2>/dev/null | awk -v title="${DOCK_TITLE}" '$2 == title { print $1; exit }'


### PR DESCRIPTION
## Summary

Resolve #2

Add configurable `@marmonitor-command` override for local development and non-standard install paths, clickable statusline attention items, and Option+` jump-back keybinding.

## Changes

**Command override (`@marmonitor-command`):**
- All `marmonitor` calls now use `$MARMONITOR_CMD` (configurable via `set -g @marmonitor-command`)
- Fallback path resolution: configured command → `/opt/homebrew/bin/marmonitor` → `/usr/local/bin/marmonitor`
- `sh -lc` wrapper ensures login shell PATH is available in tmux server context
- Applied to: `marmonitor.tmux`, `statusline.sh`, `toggle-dock.sh`

**Click actions:**
- `MouseDown1Status` binding for clickable attention items in statusline
- Routes clicks through `marmonitor status-click` with `mouse_status_range` and `client_tty`

**Jump-back (Option+\`):**
- `M-\`` keybinding to run `marmonitor jump-back`
- Returns to the tmux pane before the last Option+1~5 jump

**Other:**
- Popup height increased from 32 → 42 lines
- Preflight check uses `command_runs()` (login shell context) instead of `command_exists()`

## Checklist

- [x] Tested with `tmux source-file marmonitor.tmux`
- [x] Works when marmonitor is installed
- [x] Works when marmonitor is NOT installed (graceful fallback)
- [x] Custom `@marmonitor-*` options still work
- [ ] README updated (if user-facing changes)

## Testing

```bash
# Command override
set -g @marmonitor-command 'node ~/Documents/mjjo/marmonitor/bin/marmonitor.js'
tmux source-file ~/.tmux.conf  # uses local dev marmonitor

# Without override (default)
# unset @marmonitor-command → falls back to global marmonitor

# Jump-back
# Option+1 → jump to session → Option+` → return to original pane

# Click
# Click numbered attention item in statusline → jumps to session
```

## Risk

Medium — All shell commands now wrap through `sh -lc` for PATH resolution. If login shell is slow or has side effects, statusline refresh may be affected. Fallback to `marmonitor not found` message on failure.