### PR TITLE
[FEAT] #5 prefix+y binding for marmonitor copy-latest-turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tmux run-shell ~/.tmux/plugins/marmonitor-tmux/marmonitor.tmux
 - `status-format[1]` with `tmux-badges`
 - `prefix + a` attention popup
 - `prefix + j` jump popup
-- `prefix + y` copy latest assistant turn from the active AI pane (Claude only for v1)
+- `prefix + y` copy latest assistant turn from the active AI pane (Claude / Codex / Gemini)
 - `prefix + m` dock toggle
 - `Option+1..5` direct jump
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ tmux run-shell ~/.tmux/plugins/marmonitor-tmux/marmonitor.tmux
 - `status-format[1]` with `tmux-badges`
 - `prefix + a` attention popup
 - `prefix + j` jump popup
+- `prefix + y` copy latest assistant turn from the active AI pane (Claude only for v1)
 - `prefix + m` dock toggle
 - `Option+1..5` direct jump
 
@@ -48,6 +49,7 @@ set -g @marmonitor-format 'tmux-badges'
 set -g @marmonitor-status-line '1'
 set -g @marmonitor-attention-key 'a'
 set -g @marmonitor-jump-key 'j'
+set -g @marmonitor-copy-turn-key 'y'
 set -g @marmonitor-dock-key 'm'
 set -g @marmonitor-direct-jump 'on'
 set -g @marmonitor-interval '5'

--- a/marmonitor.tmux
+++ b/marmonitor.tmux
@@ -51,6 +51,7 @@ fi
 format=$(get_opt "@marmonitor-format" "tmux-badges")
 status_line=$(get_opt "@marmonitor-status-line" "1")
 attention_key=$(get_opt "@marmonitor-attention-key" "a")
+copy_turn_key=$(get_opt "@marmonitor-copy-turn-key" "y")
 dock_key=$(get_opt "@marmonitor-dock-key" "m")
 direct_jump=$(get_opt "@marmonitor-direct-jump" "on")
 status_interval=$(get_opt "@marmonitor-interval" "2")
@@ -118,6 +119,13 @@ check_key_conflict() {
 # Attention popup (prefix + key)
 check_key_conflict "$attention_key" prefix
 tmux bind-key "$attention_key" display-popup -E -w 120 -h 42 "sh -lc '$MARMONITOR_CMD attention --interactive --limit 12'"
+
+# Copy latest assistant turn (prefix + key)
+# Passes the active pane's pid directly so marmonitor maps the right AI session
+# even when the binding fires from a context where tmux display-message would
+# return a different pane.
+check_key_conflict "$copy_turn_key" prefix
+tmux bind-key "$copy_turn_key" run-shell "$CURRENT_DIR/scripts/copy-latest-turn.sh \"$MARMONITOR_CMD\" \"#{pane_pid}\""
 
 # Dock toggle (prefix + key)
 check_key_conflict "$dock_key" prefix

--- a/scripts/copy-latest-turn.sh
+++ b/scripts/copy-latest-turn.sh
@@ -22,15 +22,18 @@ if [ -z "$PANE_PID" ]; then
   exit 0
 fi
 
-# Parse MARMONITOR_CMD as a shell command line so quoted paths survive:
+# Interpret MARMONITOR_CMD as a shell command line so quoted paths survive:
 #   set -g @marmonitor-command 'node "/Users/me/path with spaces/marmonitor.js"'
-# `read -ra` performs only word splitting and would break the above; the
-# `eval set --` form honours real shell quoting and assigns the resulting
-# argv to "$@". This trusts the tmux option value as user-owned config
-# (same trust level as e.g. .tmux.conf binding strings).
+# `read -ra` performs only word splitting and would break the above. `eval set --`
+# runs the full shell-quote/expansion pass before assigning argv to "$@", which
+# means shell metacharacters in MARMONITOR_CMD ARE evaluated. This is the same
+# trust level as a binding line in .tmux.conf — the tmux option is user-owned
+# config, not untrusted input. If you ever need to accept the value from an
+# untrusted source, replace this with a literal argv array via tmux options.
 eval "set -- $MARMONITOR_CMD"
 
-# Exec marmonitor with argv-safe positional args. PANE_PID is fully quoted.
+# Exec marmonitor. PANE_PID is fully quoted so it stays a single argv element
+# regardless of its value; the marmonitor argv came from the trusted eval above.
 output=$("$@" copy-latest-turn --pane-pid "$PANE_PID" 2>&1)
 first_line=$(printf '%s' "$output" | head -n 1)
 

--- a/scripts/copy-latest-turn.sh
+++ b/scripts/copy-latest-turn.sh
@@ -2,12 +2,15 @@
 #
 # marmonitor-tmux — copy latest AI turn from the active pane.
 #
-# Called from prefix+y binding. Receives the pane_pid as #{pane_pid}
-# format-substituted at binding-fire time so the active pane is resolved
-# even when run-shell context is ambiguous.
+# Called from prefix+y binding. Receives pane_pid as #{pane_pid} format-
+# substituted at binding-fire time so the active pane is resolved even when
+# run-shell context is ambiguous.
 #
-# Calls marmonitor copy-latest-turn (Claude only for v1) and surfaces
-# the first line of output (success message or error) via tmux display-message.
+# Surfaces the first line of marmonitor's combined stdout+stderr via tmux
+# display-message so success ("marmonitor: copied AI turn ...") and error
+# messages ("No AI session in this tmux pane.", "Codex rollout file not
+# found...", etc.) appear the same way, and statusline never shows
+# "returned 1".
 
 set -u
 
@@ -19,11 +22,15 @@ if [ -z "$PANE_PID" ]; then
   exit 0
 fi
 
-# Collect stdout + stderr, surface only the first line so the tmux message
-# stays a single line. Exit code is intentionally ignored: failure cases
-# (no AI session, unsupported agent, no turn, clipboard failure) all print
-# a descriptive first-line message to stderr that we already want to show.
-output=$(sh -lc "$MARMONITOR_CMD copy-latest-turn --pane-pid $PANE_PID" 2>&1)
+# Split MARMONITOR_CMD into argv so users can set @marmonitor-command to a
+# multi-token value like "node /path/to/marmonitor.js" without it being
+# concatenated into a fragile single shell string. `read -ra` (bash 3.2+)
+# is safer than eval here — it performs word splitting only, no metacharacter
+# evaluation.
+read -ra MARM_ARGV <<<"$MARMONITOR_CMD"
+
+# Exec marmonitor with argv-safe positional args. PANE_PID is fully quoted.
+output=$("${MARM_ARGV[@]}" copy-latest-turn --pane-pid "$PANE_PID" 2>&1)
 first_line=$(printf '%s' "$output" | head -n 1)
 
 if [ -z "$first_line" ]; then

--- a/scripts/copy-latest-turn.sh
+++ b/scripts/copy-latest-turn.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# marmonitor-tmux — copy latest AI turn from the active pane.
+#
+# Called from prefix+y binding. Receives the pane_pid as #{pane_pid}
+# format-substituted at binding-fire time so the active pane is resolved
+# even when run-shell context is ambiguous.
+#
+# Calls marmonitor copy-latest-turn (Claude only for v1) and surfaces
+# the first line of output (success message or error) via tmux display-message.
+
+set -u
+
+MARMONITOR_CMD="${1:-marmonitor}"
+PANE_PID="${2:-}"
+
+if [ -z "$PANE_PID" ]; then
+  tmux display-message -d 2000 "marmonitor: missing pane_pid for turn copy"
+  exit 0
+fi
+
+# Collect stdout + stderr, surface only the first line so the tmux message
+# stays a single line. Exit code is intentionally ignored: failure cases
+# (no AI session, unsupported agent, no turn, clipboard failure) all print
+# a descriptive first-line message to stderr that we already want to show.
+output=$(sh -lc "$MARMONITOR_CMD copy-latest-turn --pane-pid $PANE_PID" 2>&1)
+first_line=$(printf '%s' "$output" | head -n 1)
+
+if [ -z "$first_line" ]; then
+  first_line="marmonitor: copy-latest-turn produced no output"
+fi
+
+tmux display-message -d 2000 "$first_line"
+exit 0

--- a/scripts/copy-latest-turn.sh
+++ b/scripts/copy-latest-turn.sh
@@ -22,15 +22,16 @@ if [ -z "$PANE_PID" ]; then
   exit 0
 fi
 
-# Split MARMONITOR_CMD into argv so users can set @marmonitor-command to a
-# multi-token value like "node /path/to/marmonitor.js" without it being
-# concatenated into a fragile single shell string. `read -ra` (bash 3.2+)
-# is safer than eval here — it performs word splitting only, no metacharacter
-# evaluation.
-read -ra MARM_ARGV <<<"$MARMONITOR_CMD"
+# Parse MARMONITOR_CMD as a shell command line so quoted paths survive:
+#   set -g @marmonitor-command 'node "/Users/me/path with spaces/marmonitor.js"'
+# `read -ra` performs only word splitting and would break the above; the
+# `eval set --` form honours real shell quoting and assigns the resulting
+# argv to "$@". This trusts the tmux option value as user-owned config
+# (same trust level as e.g. .tmux.conf binding strings).
+eval "set -- $MARMONITOR_CMD"
 
 # Exec marmonitor with argv-safe positional args. PANE_PID is fully quoted.
-output=$("${MARM_ARGV[@]}" copy-latest-turn --pane-pid "$PANE_PID" 2>&1)
+output=$("$@" copy-latest-turn --pane-pid "$PANE_PID" 2>&1)
 first_line=$(printf '%s' "$output" | head -n 1)
 
 if [ -z "$first_line" ]; then


### PR DESCRIPTION
## Summary

Resolve #5. Supersedes #4 (popup navigator attempt; close on merge).

Bind `prefix+y` (configurable via `@marmonitor-copy-turn-key`) to the main
repo's new `marmonitor copy-latest-turn` (`mjjo16/marmonitor#62`). Single
keystroke = copy the latest assistant turn of whichever agent runs in the
active pane (Claude / Codex / Gemini).

## Changes

- **`marmonitor.tmux`** — `@marmonitor-copy-turn-key` option (default `y`).
  Format-substitutes `#{pane_pid}` at binding-fire time so the active pane
  is resolved by tmux itself; no `display-message -p '#{pane_pid}'` re-query
  inside `run-shell` (that approach failed in #4 because `run-shell` context
  can resolve to a different pane).
- **`scripts/copy-latest-turn.sh` (new)** — wraps `marmonitor copy-latest-turn`.
  - Surfaces only the first line of stdout+stderr via `tmux display-message -d 2000`,
    so success and error messages share the same UI and the statusline never
    shows `returned 1` (`exit 0` always).
  - Parses `@marmonitor-command` (default `marmonitor`) with `eval "set -- $MARMONITOR_CMD"`
    so quoted paths like `node "/Users/me/path with spaces/marmonitor.js"` survive
    (F8). Comment is explicit that shell metacharacters ARE evaluated — trust
    model is "user-owned tmux config, same level as a `.tmux.conf` binding line"
    (F2 wording clarification).
- **`README.md`** — prefix+y entry covers Claude / Codex / Gemini.

## Checklist

- [x] Tested with `tmux source-file marmonitor.tmux`
- [x] Works when marmonitor is installed
- [x] Works when marmonitor is NOT installed (display-message surfaces the error)
- [x] Custom `@marmonitor-*` options still work (including `@marmonitor-command` with quoted paths)
- [x] README updated

## Testing

- `bash -n scripts/copy-latest-turn.sh` clean.
- Live:
  - Claude pane: `prefix+y` → "marmonitor: copied AI turn from Claude Code (pid …, …chars)" ✅
  - Codex pane: same flow, surfaces F4-aligned binding-registry result ✅
  - Non-AI pane (zsh prompt): "No AI session in this tmux pane." displayed instead of `returned 1` noise ✅
  - `@marmonitor-command 'node /path/to/marmonitor.js'` override still works (F8 eval-set parse) ✅

## Risk

Low.
- Wrapper exits 0 unconditionally; failure modes surface via tmux message only.
- The `eval set --` step trusts the tmux option value (`@marmonitor-command`). This is the same trust level as a `run-shell` line in `.tmux.conf`, but the comment now states it explicitly so future readers don't mistake it for argv-safe sandboxing.
- No change to other bindings, statusline rendering, or the dock.